### PR TITLE
Stamper trait to impl downstream, make ureq optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,12 @@ base64 = "0.21.0"
 bitcoin_hashes = "0.11.0"
 opentimestamps = "0.1.2"
 thiserror = "1.0.38"
-ureq = "2.6.2"
+ureq = { version = "2.6.2", optional = true }
+
+[features]
+default = [ "ureq" ]
+ureq = ["dep:ureq"]
+
+[[example]]
+name = "stamp"
+required-features = ["ureq"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Ureq error: {0}")]
-    Ureq(Box<ureq::Error>), // boxed because ureq::Error is 240 bytes
+    #[error("Transport error: {0}")]
+    Transport(String),
 
     #[error(transparent)]
     Hashes(#[from] bitcoin_hashes::Error),
@@ -24,10 +24,4 @@ pub enum Error {
         aggregators: usize,
         at_least: usize,
     },
-}
-
-impl From<ureq::Error> for Error {
-    fn from(value: ureq::Error) -> Self {
-        Error::Ureq(Box::new(value))
-    }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,7 +1,7 @@
-use std::time::Duration;
+use crate::Stamper;
 
 #[non_exhaustive]
-pub struct Options {
+pub struct Options<S: Stamper> {
     /// POST digest URLs of the aggregator servers.
     pub aggregators: Vec<String>,
 
@@ -10,23 +10,20 @@ pub struct Options {
     /// Default: 2
     pub at_least: usize,
 
-    /// Overall timeout for each request to a aggregator in milliseconds.
-    ///
-    /// Default: 5 seconds
-    pub timeout: Duration,
+    pub stamper: S,
 }
-impl Options {
+impl<S: Stamper> Options<S> {
     pub(crate) fn digest_endpoints(&self) -> impl Iterator<Item = String> + '_ {
         self.aggregators.iter().map(|agg| format!("{agg}/digest"))
     }
 }
 
-impl Default for Options {
-    fn default() -> Self {
+impl<S: Stamper> Options<S> {
+    pub fn with_stamper(stamper: S) -> Self {
         Self {
             aggregators: AGGREGATORS.map(|s| s.to_string()).to_vec(),
             at_least: 2,
-            timeout: Duration::from_secs(5),
+            stamper,
         }
     }
 }

--- a/src/stamper.rs
+++ b/src/stamper.rs
@@ -1,0 +1,61 @@
+use std::{fmt::Display, time::Duration};
+
+pub trait Stamper: Send + Sync + Sized {
+    fn new(timeout: Duration) -> Result<Self, String>;
+    fn stamp(&self, digest_endpoint: &str, digest: &[u8]) -> Result<Vec<u8>, StamperError>;
+}
+
+#[derive(Debug)]
+pub enum StamperError {
+    Status(u16),
+    IoError(std::io::Error),
+    Transport(String),
+}
+
+impl Display for StamperError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for StamperError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            StamperError::Status(_) | StamperError::Transport(_) => None,
+            StamperError::IoError(e) => Some(e),
+        }
+    }
+}
+
+#[cfg(feature = "ureq")]
+pub(crate) mod ureq {
+    use std::time::Duration;
+
+    use super::{Stamper, StamperError};
+
+    pub(crate) struct UreqStamper(ureq::Agent);
+
+    impl Stamper for UreqStamper {
+        fn new(timeout: Duration) -> Result<Self, String> {
+            Ok(Self(ureq::builder().timeout(timeout).build()))
+        }
+
+        fn stamp(&self, digest_endpoint: &str, digest: &[u8]) -> Result<Vec<u8>, StamperError> {
+            let resp = self
+                .0
+                .post(digest_endpoint)
+                .send(digest)
+                .map_err(|e| StamperError::Transport(e.to_string()))?;
+            if resp.status() == 200 {
+                let mut result = vec![];
+                resp.into_reader()
+                    .read_to_end(&mut result)
+                    .map_err(|e| StamperError::IoError(e))?;
+
+                Ok(result)
+            } else {
+                Err(StamperError::Status(resp.status()))
+            }
+        }
+    }
+}


### PR DESCRIPTION
By providing a trait to perform the needed http request, downstream users could use the http implementation they very probably have in their deps